### PR TITLE
Deleted itoa method.

### DIFF
--- a/inc/utils.h
+++ b/inc/utils.h
@@ -42,6 +42,5 @@
 */
 char* ftoa(float f);
 void ltoa(char *buf, unsigned long i, int base);
-void itoa(char *buf, unsigned int i, int base);
 
 #endif /* UTILS_H_ */

--- a/src/utils.c
+++ b/src/utils.c
@@ -153,29 +153,3 @@ void ltoa(char *buf, unsigned long i, int base)
 		}
 	strcpy(buf, s);
 }
-
-void itoa(char *buf, unsigned int i, int base)
-{
-	char *s;
-	const int len = 10;
-	int rem;
-	char rev[len+1];
-
-	if (i == 0)
-		s = "0";
-	else
-		{
-		rev[len] = 0;
-		s = &rev[len];
-		while (i)
-			{
-			rem = i % base;
-			if (rem < 10)
-				*--s = rem + '0';
-			else if (base == 16)
-				*--s = "abcdef"[rem - 10];
-			i /= base;
-			}
-		}
-	strcpy(buf, s);
-}


### PR DESCRIPTION
This itoa method is defined in stdlib.h in gcc-arm-none-eabi-4_9-2015q3.
Because it has been defined, an error will occur.
This method is not used in PX4Flow.

Therefore, it has been deleted.

Compiler header of stdlib.h
gcc-arm-none-eabi-4_9-2015q3/arm-none-eabi/include/stdlib.h
